### PR TITLE
Modified submodule path for "opencm-registers"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,5 +2,5 @@
 	path = opencm/libopencm3
 	url = https://github.com/libopencm3/libopencm3
 [submodule "opencm-registers/libopencm3"]
-	path = opencm/libopencm3
+	path = opencm-registers/libopencm3
 	url = https://github.com/libopencm3/libopencm3


### PR DESCRIPTION
The path for the submodule in "opencm-registers/libopencm3" was incorrect and it generated an error when trying to run "submodule init". The error was:

`fatal: No url found for submodule path 'opencm-registers/libopencm3' in .gitmodules`

This commit solves the issue.